### PR TITLE
Fix missing whitespace

### DIFF
--- a/src/HTML.js
+++ b/src/HTML.js
@@ -269,7 +269,7 @@ export default class HTML extends PureComponent {
                 children = alteredChildren || children;
             }
             // Remove whitespaces to check if it's just a blank text
-            const strippedData = data && data.replace(/\s/g, '');
+            const strippedData = data && data.replace(/\s+/g, ' ');
             if (type === 'text') {
                 if (!strippedData || !strippedData.length) {
                     // This is blank, don't render an useless additional component


### PR DESCRIPTION
HTML.js collapses white space between tags. See this issue for more details: https://github.com/archriss/react-native-render-html/issues/216

The change is the proposed solution in the comments.